### PR TITLE
Shadowlands fixes fury

### DIFF
--- a/Specialization/Fury.lua
+++ b/Specialization/Fury.lua
@@ -28,15 +28,13 @@ local FR = {
 	Execute           = 5308,
 	ExecuteMassacre   = 280735,
 	Bloodthirst       = 23881,
-	Bloodbath		  = 335096,
+	Bloodbath	  = 335096,
 	RagingBlow        = 85288,
 	CrushingBlow	  = 335097,
 	Bladestorm        = 46924,
 	DragonRoar        = 118000,
 	SuddenDeathAura   = 280776,
-	Condemn			  = 317485,
-	VictoryRush		  = 34428,
-	Victorious		  = 32216,
+	Condemn           = 317485,
 };
 
 local A = {
@@ -80,10 +78,6 @@ function Warrior:Fury()
 				spellHistory[1] == FR.Rampage and (debuff[FR.SiegebreakerAura].up or not talents[FR.Siegebreaker])
 			)
 		);
-	end
-
-	if buff[FR.Victorious].up then
-		return FR.VictoryRush
 	end
 
 	-- furious_slash,if=talent.furious_slash.enabled&(buff.furious_slash.stack<3|buff.furious_slash.remains<3|(cooldown.recklessness.remains<3&buff.furious_slash.remains<9));


### PR DESCRIPTION
This needs work but it fixes a couple of things.

- When Recklessness is active, it now recommends `Crushing Blow` in place of `Raging Blow` and `Bloodbath` in place of `Bloodthirst`
- It now works with Condemn in place of Execute.

Hopefully this will stop errors when a Fury warrior gets Condemn and when using Recklessness.